### PR TITLE
fix: invalid utf8 winner string

### DIFF
--- a/pkg/l1Listener/l1Listener.go
+++ b/pkg/l1Listener/l1Listener.go
@@ -1,6 +1,7 @@
 package l1Listener
 
 import (
+	"bytes"
 	"context"
 	"math/big"
 	"time"
@@ -75,7 +76,7 @@ func (l *L1Listener) Start(ctx context.Context) <-chan struct{} {
 					continue
 				}
 
-				winner := string(header.Extra)
+				winner := string(bytes.ToValidUTF8(header.Extra, []byte("�")))
 				if len(winner) == 0 {
 					log.Warn().
 						Int64("block", header.Number.Int64()).


### PR DESCRIPTION
Fixes the following panic:
```
goroutine 71 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).WithLabelValues(...)
	github.com/prometheus/client_golang@v1.14.0/prometheus/counter.go:254
github.com/primevprotocol/mev-oracle/pkg/l1Listener.(*L1Listener).Start.func1()
	github.com/primevprotocol/mev-oracle/pkg/l1Listener/l1Listener.go:93 +0x5d1
created by github.com/primevprotocol/mev-oracle/pkg/l1Listener.(*L1Listener).Start in goroutine 1
	github.com/primevprotocol/mev-oracle/pkg/l1Listener/l1Listener.go:48 +0xb2
panic: label value "\u0603\x01\r\v\x84geth\x88go1.21.6\x85linux" is not valid UTF-8
```