### PR TITLE
fix: fee suggestion

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -292,19 +292,20 @@ func setBuilderMapping(
 		return err
 	}
 	auth.Nonce = big.NewInt(int64(nonce))
+
+	// Returns priority fee per gas
 	gasTip, err := client.SuggestGasTipCap(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Returns priority fee per gas + base fee per gas
 	gasPrice, err := client.SuggestGasPrice(ctx)
 	if err != nil {
 		return err
 	}
 
-	gasFeeCap := new(big.Int).Add(gasTip, gasPrice)
-
-	auth.GasFeeCap = gasFeeCap
+	auth.GasFeeCap = gasPrice
 	auth.GasTipCap = gasTip
 
 	txn, err := rc.AddBuilderAddress(auth, builderName, common.HexToAddress(builderAddress))

--- a/pkg/settler/settler.go
+++ b/pkg/settler/settler.go
@@ -110,19 +110,19 @@ func (s *Settler) getTransactOpts(ctx context.Context) (*bind.TransactOpts, erro
 	}
 	auth.Nonce = big.NewInt(int64(nonce))
 
+	// Returns priority fee per gas
 	gasTip, err := s.client.SuggestGasTipCap(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Returns priority fee per gas + base fee per gas
 	gasPrice, err := s.client.SuggestGasPrice(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	gasFeeCap := new(big.Int).Add(gasTip, gasPrice)
-
-	auth.GasFeeCap = gasFeeCap
+	auth.GasFeeCap = gasPrice
 	auth.GasTipCap = gasTip
 
 	return auth, nil


### PR DESCRIPTION
Similar to https://github.com/primevprotocol/mev-commit/pull/193, `eth_gasPrice` rpc method returns a suggested priority fee per gas + base fee per gas. Our tx param logic previously assumed the rpc was returning only base fee per gas