### PR TITLE
Wait 64 blocks before processing commitments

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -154,6 +154,13 @@ var (
 		EnvVars: []string{"MEV_ORACLE_KEYSTORE_PATH"},
 		Value:   filepath.Join(defaultConfigDir, defaultKeystore),
 	})
+
+	optionWaitOnFinality = altsrc.NewBoolFlag(&cli.BoolFlag{
+		Name:    "wait-on-finality",
+		Usage:   "wait for finality before sending settlement",
+		EnvVars: []string{"MEV_ORACLE_WAIT_ON_FINALITY"},
+		Value:   true,
+	})
 )
 
 func main() {
@@ -175,6 +182,7 @@ func main() {
 		optionOverrideWinners,
 		optionKeystorePath,
 		optionKeystorePassword,
+		optionWaitOnFinality,
 	}
 	app := &cli.App{
 		Name:  "mev-oracle",
@@ -308,6 +316,7 @@ func launchOracleWithConfig(c *cli.Context) error {
 		PgDbname:            c.String(optionPgDbname.Name),
 		LaggerdMode:         c.Int(optionLaggerdMode.Name),
 		OverrideWinners:     c.StringSlice(optionOverrideWinners.Name),
+		WaitOnFinality:      c.Bool(optionWaitOnFinality.Name),
 	})
 	if err != nil {
 		return fmt.Errorf("failed starting node: %w", err)

--- a/pkg/l1Listener/l1Listener_test.go
+++ b/pkg/l1Listener/l1Listener_test.go
@@ -25,7 +25,7 @@ func TestL1Listener(t *testing.T) {
 		errC:    make(chan error, 1),
 	}
 
-	l := l1Listener.NewL1Listener(ethClient, reg)
+	l := l1Listener.NewL1Listener(ethClient, reg, true)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	cl := l1Listener.SetCheckInterval(100 * time.Millisecond)

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -38,6 +38,7 @@ type Options struct {
 	PgDbname            string
 	LaggerdMode         int
 	OverrideWinners     []string
+	WaitOnFinality      bool
 }
 
 type Node struct {
@@ -127,7 +128,7 @@ func NewNode(opts *Options) (*Node, error) {
 		}
 	}
 
-	l1Lis := l1Listener.NewL1Listener(listenerL1Client, st)
+	l1Lis := l1Listener.NewL1Listener(listenerL1Client, st, opts.WaitOnFinality)
 	l1LisClosed := l1Lis.Start(ctx)
 
 	callOpts := bind.CallOpts{


### PR DESCRIPTION
* This is a stop-gap implementation to limit exposure to re-orgs on Ethereum.
* To have a complete implementation, we plan to retreive information about finality and store it into our DB